### PR TITLE
feat: adiciona sanitização do parâmetro external-id na URI

### DIFF
--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -26,6 +26,7 @@ final class Uri
                     '/\/(?<=\/)([A-Z]{3}-?\d[0-9A-Z]\d{2})(?=\/)?/i',
                     '/\/(?<=\/)[0-9A-F]{16,24}(?=\/)?/i',
                     '/\/(?<=\/)\d+(?=\/)?/',
+                    '/\/(?<=\/)R[RN]\d{16}[A-Za-z0-9]{11}/',
                 ],
             ),
             array_merge(
@@ -37,6 +38,7 @@ final class Uri
                     '/<LICENSE-PLATE>',
                     '/<OID>',
                     '/<NUMBER>',
+                    '/<EXTERNAL-ID>',
                 ],
             ),
             '/' . ltrim($uri, '/'),

--- a/tests/Cases/UriTest.php
+++ b/tests/Cases/UriTest.php
@@ -150,4 +150,15 @@ final class UriTest extends TestCase
         self::assertSame('/v7/test/<SHA256-ID>/<SHA256-ID>/<SHA256-ID>', Uri::sanitize('/v7/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7', $uriMask));
         self::assertSame('/v8/test/<SHA256-ID>/<SHA256-ID>/<SHA256-ID>/', Uri::sanitize('/v8/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/', $uriMask));
     }
+
+    public function testClearUriExternalIds(): void
+    {
+        self::assertSame('/v1/test', Uri::sanitize('/v1/test'));
+        self::assertSame('/v1/test/<EXTERNAL-ID>', Uri::sanitize('/v1/test/RR2101818220123720H9KJTERfw1a'));
+        self::assertSame('/v3/test/<EXTERNAL-ID>/bar', Uri::sanitize('/v3/test/RN2401818220250720G4KJTQyU6Ds/bar'));
+        self::assertSame('/v4/test/<EXTERNAL-ID>/bar/<EXTERNAL-ID>/', Uri::sanitize('/v4/test/RR2101818220123720H9KJTERfw1a/bar/RN2401818220250720G4KJTQyU6Ds/'));
+        self::assertSame('/v5/test/<EXTERNAL-ID>/<EXTERNAL-ID>', Uri::sanitize('/v5/test/RR2101818220123720H9KJTERfw1a/RN2401818220250720G4KJTQyU6Ds'));
+        self::assertSame('/v7/test/<EXTERNAL-ID>/<EXTERNAL-ID>/<EXTERNAL-ID>/', Uri::sanitize('/v7/test/RR2101818220123720H9KJTERfw1a/RN2001818220123720H9KJTERBd52/RR2123818220123730H9KJTERBd52/'));
+        self::assertSame('/v9/test/<EXTERNAL-ID>/bar/<NUMBER>', Uri::sanitize('/v9/test/RR2101818220123720H9KJTERfw1a/bar/12345'));
+    }
 }


### PR DESCRIPTION
This pull request enhances the URI sanitization logic in the `Uri` utility by adding support for masking external IDs in URIs, and introduces corresponding test coverage to ensure correct behavior. The main changes focus on identifying and masking external IDs that match a specific pattern.

### URI Sanitization Improvements

* Added a new regular expression to the `sanitize` method in `src/Support/Uri.php` to detect and mask external IDs matching the pattern `/^R[RN]\d{16}[A-Za-z0-9]{11}$/`.
* Updated the replacement list in `sanitize` to include the `<EXTERNAL-ID>` placeholder for matched external IDs.

### Test Coverage

* Added a new test method `testClearUriExternalIds` in `tests/Cases/UriTest.php` to verify that URIs containing external IDs are properly sanitized and replaced with the `<EXTERNAL-ID>` placeholder.